### PR TITLE
Refactor/task update io guard

### DIFF
--- a/internal/tasks/update.go
+++ b/internal/tasks/update.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/AJMerr/hydianflow/internal/database"
@@ -75,10 +76,20 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if req.RepoName != nil {
-		t.RepoName = req.RepoName
+		s := strings.TrimSpace(*req.RepoName)
+		if s == "" {
+			t.RepoName = nil
+		} else {
+			t.RepoName = &s
+		}
 	}
 	if req.BranchHint != nil {
-		t.BranchHint = req.BranchHint
+		s := strings.TrimSpace(*req.BranchHint)
+		if s == "" {
+			t.BranchHint = nil
+		} else {
+			t.BranchHint = &s
+		}
 	}
 
 	if err := h.DB.Save(&t).Error; err != nil {

--- a/internal/tasks/update.go
+++ b/internal/tasks/update.go
@@ -18,7 +18,12 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 		utils.Error(w, http.StatusUnauthorized, "unauthorized", "login required")
 		return
 	}
-	id, _ := strconv.ParseUint(chi.URLParam(r, "id"), 10, 64)
+	id64, err := strconv.ParseUint(chi.URLParam(r, "id"), 10, 64)
+	if err != nil || id64 == 0 {
+		utils.Error(w, http.StatusBadRequest, "bad_id", "invalid task id")
+		return
+	}
+	id := uint(id64)
 
 	var t database.Task
 	if err := h.DB.Where("id = ? AND creator_id = ?", id, uid).First(&t).Error; err != nil {
@@ -31,7 +36,9 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req TaskUpdateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
 		utils.Error(w, http.StatusBadRequest, "bad_json", "invalid JSON body")
 		return
 	}


### PR DESCRIPTION
Made minor tweaks to update.go:

- ParseUint errors for IDs are no longer ignored and give a proper error response
- Unknown JSON fields are now rejected and a 1MB cap is set
- Strings are normalized and null out is allowed for RepoName and BranchHint